### PR TITLE
Multiple quality improvements

### DIFF
--- a/DistributionLibrary/src/main/java/org/openintents/distribution/AboutDialog.java
+++ b/DistributionLibrary/src/main/java/org/openintents/distribution/AboutDialog.java
@@ -19,7 +19,6 @@ package org.openintents.distribution;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-
 import org.openintents.intents.AboutMiniIntents;
 import org.openintents.util.IntentUtils;
 import org.openintents.util.VersionUtils;
@@ -46,11 +45,8 @@ public class AboutDialog extends DownloadAppDialog {
         String appname = VersionUtils.getApplicationName(mContext);
         String appnameversion = mContext.getString(R.string.oi_distribution_name_and_version, appname, version);
         
-        StringBuilder sb = new StringBuilder();
-        sb.append(appnameversion);
-        sb.append("\n\n");
-        sb.append(mMessageText);
-        setMessage(sb.toString());
+        StringBuilder sb = new StringBuilder();sb.append(appnameversion).append("\n\n").append(mMessageText);
+		setMessage(sb.toString());
 	}
 	
 	public static void showDialogOrStartActivity(Activity activity, int dialogId) {

--- a/DistributionLibrary/src/main/java/org/openintents/distribution/DistributionLibrary.java
+++ b/DistributionLibrary/src/main/java/org/openintents/distribution/DistributionLibrary.java
@@ -19,8 +19,8 @@ public class DistributionLibrary {
 	
 	
 	Activity mActivity;
-	int mFirstMenuId = 0;
-	int mFirstDialogId = 0;
+	int mFirstMenuId;
+	int mFirstDialogId;
 	
 	public DistributionLibrary(Activity activity, int firstMenuId, int firstDialogId) {
 		mActivity = activity;

--- a/DistributionLibrary/src/main/java/org/openintents/distribution/DownloadAppDialog.java
+++ b/DistributionLibrary/src/main/java/org/openintents/distribution/DownloadAppDialog.java
@@ -82,8 +82,7 @@ public class DownloadAppDialog extends AlertDialog implements OnClickListener {
         mHideMarketLink = org.openintents.distribution.MarketUtils.hideMarketLink(mContext);
         
         StringBuilder sb = new StringBuilder();
-        sb.append(message);
-        sb.append(" ");
+        sb.append(message).append(" ");
         if (mMarketAvailable && !mHideMarketLink) {
         	sb.append(mContext.getString(R.string.oi_distribution_download_market_message, 
         			mDownloadAppName));

--- a/DistributionLibrary/src/main/java/org/openintents/distribution/UpdateDialog.java
+++ b/DistributionLibrary/src/main/java/org/openintents/distribution/UpdateDialog.java
@@ -16,14 +16,13 @@
 
 package org.openintents.distribution;
 
-import org.openintents.util.VersionUtils;
-
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
+import org.openintents.util.VersionUtils;
 
 /**
  * @version 2009-10-23: support Market and aTrackDog
@@ -60,10 +59,8 @@ public class UpdateDialog extends DownloadAppDialog {
         String appnameversion = mContext.getString(R.string.oi_distribution_name_and_version, appname, version);
         
         StringBuilder sb = new StringBuilder();
-        sb.append(appnameversion);
-        sb.append("\n\n");
-        sb.append(mMessageText);
-        setMessage(sb.toString());
+		sb.append(appnameversion).append("\n\n").append(mMessageText);
+		setMessage(sb.toString());
         
         setButton(BUTTON_POSITIVE, mContext.getText(R.string.oi_distribution_update_check_now), this);
     }
@@ -93,7 +90,7 @@ public class UpdateDialog extends DownloadAppDialog {
 	 * @return
 	 */
 	public static boolean isUpdateMenuNecessary(Context context) {
-		PackageInfo pi = null;
+		PackageInfo pi;
 		
 		// Test for existence of all known update checker applications.
 		for (int i = 0; i < UPDATE_CHECKER.length; i++) {

--- a/DistributionLibrary/src/main/java/org/openintents/intents/AboutMiniIntents.java
+++ b/DistributionLibrary/src/main/java/org/openintents/intents/AboutMiniIntents.java
@@ -26,13 +26,6 @@ package org.openintents.intents;
  *
  */
 public final class AboutMiniIntents {
-	
-	/**
-	 * Empty, preventing instantiation.
-	 */
-	private AboutMiniIntents() {
-		//Empty, preventing instantiation.
-	}
 
 	/**
 	 * Activity Action: Show an about dialog to display
@@ -71,5 +64,12 @@ public final class AboutMiniIntents {
 	 */
 	public static final String EXTRA_PACKAGE_NAME = 
 		"org.openintents.extra.PACKAGE_NAME";
-	
+
+	/**
+	 * Empty, preventing instantiation.
+	 */
+	private AboutMiniIntents() {
+		//Empty, preventing instantiation.
+	}
+
 }

--- a/DistributionLibrary/src/main/java/org/openintents/util/IntentUtils.java
+++ b/DistributionLibrary/src/main/java/org/openintents/util/IntentUtils.java
@@ -38,6 +38,6 @@ public class IntentUtils {
 	    List<ResolveInfo> list =
 	            packageManager.queryIntentActivities(intent,
 	                    PackageManager.MATCH_DEFAULT_ONLY);
-	    return list.size() > 0;
+	    return !list.isEmpty();
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules pmd:ConsecutiveAppendsShouldReuse - Consecutive Appends Should Reuse
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order
squid:S1854 - Dead stores should be removed
squid:S3052 - Fields should not be initialized to default values
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=pmd:ConsecutiveAppendsShouldReuse
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1854
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155

Please let me know if you have any questions.

M-Ezzat